### PR TITLE
Support the 'Task State' custom field and allow for opting out the status move

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -2,10 +2,12 @@ const ASANA_API_URL = "https://app.asana.com/api/1.0/";
 
 const CUSTOM_FIELD_NAME_STATUS = "Status";
 const CUSTOM_FIELD_NAME_TICKET_STATUS = "Ticket Status";
+const CUSTOM_FIELD_NAME_TASK_STATE = "Task State";
 
 const CUSTOM_FIELD_NAMES = [
   CUSTOM_FIELD_NAME_STATUS,
   CUSTOM_FIELD_NAME_TICKET_STATUS,
+  CUSTOM_FIELD_NAME_TASK_STATE,
 ];
 
 const NO_STATUS = "None";

--- a/index.js
+++ b/index.js
@@ -1,55 +1,62 @@
 const core = require("@actions/core");
 const { context } = require("@actions/github");
 const { getTaskStatuses, updateTaskStatus } = require("./asana_client");
-const { findAsanaTaskIds } = require("./utils");
+const { findAsanaTaskIds, shouldMoveStatus } = require("./utils");
 
 const main = async () => {
-  const foundIds = findAsanaTaskIds(context.payload.pull_request.body);
+  try {
+    const prBody = context.payload.pull_request.body;
 
-  if (!foundIds || foundIds.length === 0) {
-    core.info(">> No Asana task IDs found! Moving on 🏃");
-    return;
-  }
-
-  core.info(">> Found Asana task IDs:", foundIds);
-
-  const tasksData = await getTaskStatuses(foundIds);
-
-  tasksData.forEach(async (taskData) => {
-    core.info(
-      `>> Current status of ${taskData.taskId} is ${taskData.currentStatusName}`
-    );
-    core.info(
-      `>> Next status of ${taskData.taskId} is ${taskData.nextStatusName}`
-    );
-    if (taskData.currentStatusName !== taskData.nextStatusName) {
-      core.info(
-        `>> Moving ${taskData.taskId} from '${taskData.currentStatusName}' to '${taskData.nextStatusName}' and marking complete as '${taskData.isComplete}' ...`
-      );
-
-      await updateTaskStatus(
-        taskData.taskId,
-        taskData.customStatusFieldId,
-        taskData.nextStatusOptionId,
-        taskData.isComplete
-      );
-
-      core.info(`>> 🎉 Moving complete 🎉`);
-    } else {
-      core.info(`>> No updated needed! Moving on 🏃`);
+    if (!shouldMoveStatus(prBody)) {
+      core.info(">> Opted out of auto status update. Exiting quietly.");
+      return;
     }
-  });
-};
 
-try {
-  main();
-} catch (error) {
-  core.warning(`
-  👁👄👁
+    const foundIds = findAsanaTaskIds(prBody);
+
+    if (!foundIds || foundIds.length === 0) {
+      core.info(">> No Asana task IDs found! Moving on 🏃");
+      return;
+    }
+
+    core.info(">> Found Asana task IDs:", foundIds);
+
+    const tasksData = await getTaskStatuses(foundIds);
+
+    tasksData.forEach(async (taskData) => {
+      core.info(
+        `>> Current status of ${taskData.taskId} is ${taskData.currentStatusName}`
+      );
+      core.info(
+        `>> Next status of ${taskData.taskId} is ${taskData.nextStatusName}`
+      );
+      if (taskData.currentStatusName !== taskData.nextStatusName) {
+        core.info(
+          `>> Moving ${taskData.taskId} from '${taskData.currentStatusName}' to '${taskData.nextStatusName}' and marking complete as '${taskData.isComplete}' ...`
+        );
+
+        await updateTaskStatus(
+          taskData.taskId,
+          taskData.customStatusFieldId,
+          taskData.nextStatusOptionId,
+          taskData.isComplete
+        );
+
+        core.info(`>> 🎉 Moving complete 🎉`);
+      } else {
+        core.info(`>> No updated needed! Moving on 🏃`);
+      }
+    });
+  } catch (error) {
+    core.warning(`
+  💀🚨💀🚨💀🚨💀🚨💀🚨💀
   A problem occured!
   ---
   ${error.message}
   ---
   Exiting quietly.`);
-  return;
-}
+    return;
+  }
+};
+
+main();

--- a/utils.js
+++ b/utils.js
@@ -5,6 +5,18 @@ const {
   CUSTOM_FIELD_NAMES,
 } = require("./constants");
 
+const shouldMoveStatus = (prBody) => {
+  if (!!prBody) {
+    const moveStatusMatch = prBody.match(
+      /(?<=(<!--\s+AsanaBot:MoveStatus:))\w+(?=\s+-->)/gm
+    );
+
+    return !!moveStatusMatch ? moveStatusMatch.pop() === "true" : false;
+  }
+
+  return false;
+};
+
 const findAsanaTaskIds = (prBody) =>
   !!prBody
     ? prBody.match(/(?<=app.asana.com\/.*\/.*\/)\d+(?=(\/f$|$))/gm)
@@ -29,6 +41,7 @@ const calcNextStatus = (enumOptions) => {
 };
 
 module.exports = {
+  shouldMoveStatus,
   findAsanaTaskIds,
   filterCustomFields,
   calcNextStatus,


### PR DESCRIPTION
You now have the option to opt in/out of a tickets status move with ` <!-- AsanaBot:MoveStatus:true -->` or ` <!-- AsanaBot:MoveStatus:false -->` added to the PR body.